### PR TITLE
Fix instrumentation for short sync effects

### DIFF
--- a/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
@@ -70,7 +70,7 @@ extension Effect where Error == Never {
       completed: {
         os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sFinished", prefix)
       },
-      interrupted: {
+      disposed: {
         os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sCancelled", prefix)
       },
       value: { value in

--- a/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
@@ -62,16 +62,15 @@ extension Effect where Error == Never {
     let sid = OSSignpostID(log: log)
 
     return self.on(
-      started: {
+      starting: {
         os_signpost(
-          .begin, log: log, name: "Effect", signpostID: sid, "%sStarted from %s", prefix,
-          actionOutput
+          .begin, log: log, name: "Effect", signpostID: sid, "%sStarted from %s", prefix, actionOutput
         )
       },
       completed: {
         os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sFinished", prefix)
       },
-      disposed: {
+      interrupted: {
         os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sCancelled", prefix)
       },
       value: { value in


### PR DESCRIPTION
ReactiveSwift can call "started" after "completed" in some cases, for example if the effect is synchronous. This leads to os_signpost reporting effects that never end which have actually ended. "Starting" is always called before "completed". Also "interrupted" means cancelling according to Rs api contract.