### PR TITLE
No need to use a MutableProperty for the ViewStore state.

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -62,15 +62,18 @@ public final class ViewStore<State, Action>: ObservableObject {
     self.state = store.state
     self._send = store.send
     producer.startWithValues { [weak self] in
-      if #available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *) {
-        self?.objectWillChange.send()
-      }
       self?.state = $0
     }
   }
 
   /// The current state.
-  @MutableProperty public internal(set) var state: State
+  public private(set) var state: State {
+    willSet {
+      if #available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *) {
+        self.objectWillChange.send()
+      }
+    }
+  }
 
   @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
   public lazy var objectWillChange: ObservableObjectPublisher = ObjectWillChangePublisher()


### PR DESCRIPTION
After looking at https://github.com/pointfreeco/swift-composable-architecture/pull/199 I realised there is no reason to use a `@MutableProperty` (equivalent of `@Published`) in the ViewStore, especially since we are already calling `self.objectWillChange.send()` manually.