### PR TITLE
Change use of `publisher` to `producer`

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -28,8 +28,8 @@ enum LongLivingEffectsAction {
 
 struct LongLivingEffectsEnvironment {
   // An effect that emits Void whenever the user takes a screenshot of the device. We use this
-  // instead of `NotificationCenter.default.publisher` directly in the reducer so that we can test
-  // it.
+  // instead of `NotificationCenter.default.reactive.notifications(forName:)` directly
+  // in the reducer so that we can test it
   var userDidTakeScreenshot: Effect<Void, Never>
 }
 

--- a/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/CounterViewController.swift
@@ -66,7 +66,7 @@ final class CounterViewController: UIViewController {
       rootStackView.centerYAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.centerYAnchor),
     ])
 
-    self.viewStore.publisher.count
+    self.viewStore.producer.count
       .map(String.init)
       .assign(to: \.text, on: countLabel)
   }

--- a/Examples/CaseStudies/UIKitCaseStudies/ListsOfState.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/ListsOfState.swift
@@ -47,7 +47,7 @@ final class CountersTableViewController: UITableViewController {
 
     self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifier)
 
-    self.viewStore.publisher.counters
+    self.viewStore.producer.counters
       .startWithValues({ [weak self] in self?.dataSource = $0 })
   }
 

--- a/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/LoadThenNavigate.swift
@@ -87,7 +87,7 @@ class LazyNavigationViewController: UIViewController {
       rootStackView.centerYAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.centerYAnchor),
     ])
 
-    self.viewStore.publisher.isActivityIndicatorHidden
+    self.viewStore.producer.isActivityIndicatorHidden
       .assign(to: \.isHidden, on: activityIndicator)
 
     self.store

--- a/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/NavigateAndLoad.swift
@@ -79,7 +79,7 @@ class EagerNavigationViewController: UIViewController {
       button.centerYAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.centerYAnchor),
     ])
 
-    self.viewStore.publisher.isNavigationActive.startWithValues { [weak self] isNavigationActive in
+    self.viewStore.producer.isNavigationActive.startWithValues { [weak self] isNavigationActive in
       guard let self = self else { return }
       if isNavigationActive {
         self.navigationController?.pushViewController(

--- a/Examples/TicTacToe/Sources/Views-UIKit/GameViewController.swift
+++ b/Examples/TicTacToe/Sources/Views-UIKit/GameViewController.swift
@@ -116,13 +116,13 @@ public final class GameViewController: UIViewController {
         ])
       }
 
-    self.viewStore.publisher.title
+    self.viewStore.producer.title
       .assign(to: \.text, on: titleLabel)
 
-    self.viewStore.publisher.isPlayAgainButtonHidden
+    self.viewStore.producer.isPlayAgainButtonHidden
       .assign(to: \.isHidden, on: playAgainButton)
 
-    self.viewStore.publisher.producer.map { ($0.board, $0.isGameEnabled) }
+    self.viewStore.producer.producer.map { ($0.board, $0.isGameEnabled) }
       .skipRepeats(==)
       .startWithValues { board, isGameEnabled in
         board.enumerated().forEach { rowIdx, row in

--- a/Examples/TicTacToe/Sources/Views-UIKit/LoginViewController.swift
+++ b/Examples/TicTacToe/Sources/Views-UIKit/LoginViewController.swift
@@ -105,25 +105,25 @@ class LoginViewController: UIViewController {
       divider.heightAnchor.constraint(equalToConstant: 1),
     ])
 
-    self.viewStore.publisher.isLoginButtonEnabled
+    self.viewStore.producer.isLoginButtonEnabled
       .assign(to: \.isEnabled, on: loginButton)
 
-    self.viewStore.publisher.email
+    self.viewStore.producer.email
       .assign(to: \.text, on: emailTextField)
 
-    self.viewStore.publisher.isEmailTextFieldEnabled
+    self.viewStore.producer.isEmailTextFieldEnabled
       .assign(to: \.isEnabled, on: emailTextField)
 
-    self.viewStore.publisher.password
+    self.viewStore.producer.password
       .assign(to: \.text, on: passwordTextField)
 
-    self.viewStore.publisher.isPasswordTextFieldEnabled
+    self.viewStore.producer.isPasswordTextFieldEnabled
       .assign(to: \.isEnabled, on: passwordTextField)
 
-    self.viewStore.publisher.isActivityIndicatorHidden
+    self.viewStore.producer.isActivityIndicatorHidden
       .assign(to: \.isHidden, on: activityIndicator)
 
-    self.viewStore.publisher.alert
+    self.viewStore.producer.alert
       .startWithValues { [weak self] alert in
         guard let self = self else { return }
         guard let alert = alert else { return }

--- a/Examples/TicTacToe/Sources/Views-UIKit/NewGameViewController.swift
+++ b/Examples/TicTacToe/Sources/Views-UIKit/NewGameViewController.swift
@@ -101,13 +101,13 @@ class NewGameViewController: UIViewController {
       rootStackView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
     ])
 
-    self.viewStore.publisher.isLetsPlayButtonEnabled
+    self.viewStore.producer.isLetsPlayButtonEnabled
       .assign(to: \.isEnabled, on: letsPlayButton)
 
-    self.viewStore.publisher.oPlayerName
+    self.viewStore.producer.oPlayerName
       .assign(to: \.text, on: playerOTextField)
 
-    self.viewStore.publisher.xPlayerName
+    self.viewStore.producer.xPlayerName
       .assign(to: \.text, on: playerXTextField)
 
     self.store

--- a/Examples/TicTacToe/Sources/Views-UIKit/TwoFactorViewController.swift
+++ b/Examples/TicTacToe/Sources/Views-UIKit/TwoFactorViewController.swift
@@ -73,16 +73,16 @@ public final class TwoFactorViewController: UIViewController {
       rootStackView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
     ])
 
-    self.viewStore.publisher.isActivityIndicatorHidden
+    self.viewStore.producer.isActivityIndicatorHidden
       .assign(to: \.isHidden, on: activityIndicator)
 
-    self.viewStore.publisher.code
+    self.viewStore.producer.code
       .assign(to: \.text, on: codeTextField)
 
-    self.viewStore.publisher.isLoginButtonEnabled
+    self.viewStore.producer.isLoginButtonEnabled
       .assign(to: \.isEnabled, on: loginButton)
 
-    self.viewStore.publisher.alert
+    self.viewStore.producer.alert
       .startWithValues { [weak self] alert in
         guard let self = self else { return }
         guard let alert = alert else { return }

--- a/README.md
+++ b/README.md
@@ -225,11 +225,11 @@ It is also straightforward to have a UIKit controller driven off of this store. 
 
       // Omitted: Add subviews and set up constraints...
 
-      self.viewStore.publisher
+      self.viewStore.producer
         .map(String.init)
         .assign(to: \.text, on: countLabel)
 
-      self.viewStore.publisher.numberFactAlert
+      self.viewStore.producer.numberFactAlert
         .startWithValues { [weak self] numberFactAlert in
           let alertController = UIAlertController(
             title: numberFactAlert, message: nil, preferredStyle: .alert
@@ -381,7 +381,7 @@ If you are interested in contributing a wrapper library for a framework that we 
 
     In some ways TCA is a little more opinionated than the other libraries. For example, Redux is not prescriptive with how one executes side effects, but TCA requires all side effects to be modeled in the `Effect` type and returned from the reducer.
 
-    In other ways TCA is a little more lax than the other libraries. For example, Elm controls what kinds of effects can be created via the `Cmd` type, but TCA allows an escape hatch to any kind of effect since `Effect` conforms to the Combine `Publisher` protocol.
+    In other ways TCA is a little more lax than the other libraries. For example, Elm controls what kinds of effects can be created via the `Cmd` type, but TCA allows an escape hatch to any kind of effect since `Effect` is just a ReactiveSwift `SignalProducer`.
 
     And then there are certain things that TCA prioritizes highly that are not points of focus for Redux, Elm, or most other libraries. For example, composition is very important aspect of TCA, which is the process of breaking down large features into smaller units that can be glued together. This is accomplished with the `pullback` and `combine` operators on reducers, and it aids in handling complex features as well as modularization for a better-isolated code base and improved compile times.
   </details>

--- a/Sources/ComposableArchitecture/Effect.swift
+++ b/Sources/ComposableArchitecture/Effect.swift
@@ -110,7 +110,7 @@ extension Effect {
     }
   }
 
-  /// Turns any publisher into an `Effect` that cannot fail by wrapping its output and failure in a
+  /// Turns any producer into an `Effect` that cannot fail by wrapping its output and failure in a
   /// result.
   ///
   /// This can be useful when you are working with a failing API but want to deliver its data to an

--- a/Sources/ComposableArchitecture/Internal/Throttling.swift
+++ b/Sources/ComposableArchitecture/Internal/Throttling.swift
@@ -11,7 +11,7 @@ extension Effect {
   ///     the time system of the scheduler.
   ///   - scheduler: The scheduler you want to deliver the throttled output to.
   ///   - latest: A boolean value that indicates whether to publish the most recent element. If
-  ///     `false`, the publisher emits the first element received during the interval.
+  ///     `false`, the producer emits the first element received during the interval.
   /// - Returns: An effect that emits either the most-recent or first element received during the
   ///   specified interval.
   func throttle(

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -14,7 +14,7 @@ import CasePaths
 /// - Note: The thread on which effects output is important. An effect's output is immediately sent
 ///   back into the store, and `Store` is not thread safe. This means all effects must receive
 ///   values on the same thread, **and** if the `Store` is being used to drive UI then all output
-///   must be on the main thread. You can use the `Publisher` method `receive(on:)` for make the
+///   must be on the main thread. You can use the `SignalProducer` method `observe(on:)` for make the
 ///   effect output its values on the thread of your choice.
 public struct Reducer<State, Action, Environment> {
   private let reducer: (inout State, Action, Environment) -> Effect<Action, Never>

--- a/Sources/ComposableArchitecture/Store.swift
+++ b/Sources/ComposableArchitecture/Store.swift
@@ -80,13 +80,13 @@ public final class Store<State, Action> {
     self.scope(state: toLocalState, action: { $0 })
   }
 
-  /// Scopes the store to a publisher of stores of more local state and local actions.
+  /// Scopes the store to a producer of stores of more local state and local actions.
   ///
   /// - Parameters:
-  ///   - toLocalState: A function that transforms a publisher of `State` into a publisher of
+  ///   - toLocalState: A function that transforms a producer of `State` into a producer of
   ///     `LocalState`.
   ///   - fromLocalAction: A function that transforms `LocalAction` into `Action`.
-  /// - Returns: A publisher of stores with its domain (state and action) transformed.
+  /// - Returns: A producer of stores with its domain (state and action) transformed.
   public func scope<LocalState, LocalAction>(
     state toLocalState: @escaping (Effect<State, Never>) -> Effect<LocalState, Never>,
     action fromLocalAction: @escaping (LocalAction) -> Action
@@ -118,11 +118,11 @@ public final class Store<State, Action> {
       }
   }
 
-  /// Scopes the store to a publisher of stores of more local state and local actions.
+  /// Scopes the store to a producer of stores of more local state and local actions.
   ///
-  /// - Parameter toLocalState: A function that transforms a publisher of `State` into a publisher
+  /// - Parameter toLocalState: A function that transforms a producer of `State` into a producer
   ///   of `LocalState`.
-  /// - Returns: A publisher of stores with its domain (state and action)
+  /// - Returns: A producer of stores with its domain (state and action)
   ///   transformed.
   public func scope<LocalState>(
     state toLocalState: @escaping (Effect<State, Never>) -> Effect<LocalState, Never>
@@ -193,16 +193,16 @@ public final class Store<State, Action> {
   }
 }
 
-/// A publisher of store state.
+/// A producer of store state.
 @dynamicMemberLookup
-public struct StorePublisher<State>: SignalProducerConvertible {
+public struct StoreProducer<State>: SignalProducerConvertible {
   public let producer: Effect<State, Never>
 
   init(_ upstream: Effect<State, Never>) {
     self.producer = upstream
   }
 
-  /// Returns the resulting publisher of a given key path.
+  /// Returns the resulting producer of a given key path.
   public subscript<LocalState>(
     dynamicMember keyPath: KeyPath<State, LocalState>
   ) -> Effect<LocalState, Never>

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -33,7 +33,7 @@ import SwiftUI
 ///     func viewDidLoad() {
 ///       super.viewDidLoad()
 ///
-///       self.viewStore.publisher.count
+///       self.viewStore.producer.count
 ///         .startWithValues { [weak self] in self?.countLabel.text = $0 }
 ///     }
 ///
@@ -43,9 +43,8 @@ import SwiftUI
 ///
 @dynamicMemberLookup
 public final class ViewStore<State, Action>: ObservableObject {
-  /// A publisher of state.
-  public let publisher: StorePublisher<State>
-  public let producer: SignalProducer<State, Never>
+  /// A producer of state.
+  public let producer: StoreProducer<State>
 
   /// Initializes a view store from a store.
   ///
@@ -57,8 +56,8 @@ public final class ViewStore<State, Action>: ObservableObject {
     _ store: Store<State, Action>,
     removeDuplicates isDuplicate: @escaping (State, State) -> Bool
   ) {
-    self.producer = store.$state.producer.skipRepeats(isDuplicate)
-    self.publisher = StorePublisher(producer)
+    let producer = store.$state.producer.skipRepeats(isDuplicate)
+    self.producer = StoreProducer(producer)
     self.state = store.state
     self._send = store.send
     producer.startWithValues { [weak self] in

--- a/Tests/ComposableArchitectureTests/MemoryManagementTests.swift
+++ b/Tests/ComposableArchitectureTests/MemoryManagementTests.swift
@@ -14,7 +14,7 @@ final class MemoryManagementTests: XCTestCase {
     let viewStore = ViewStore(store)
 
     var count = 0
-    viewStore.producer.startWithValues { count = $0 }
+    viewStore.producer.producer.startWithValues { count = $0 }
 
     XCTAssertEqual(count, 0)
     viewStore.send(())
@@ -29,7 +29,7 @@ final class MemoryManagementTests: XCTestCase {
     let viewStore = ViewStore(Store(initialState: 0, reducer: counterReducer, environment: ()))
 
     var count = 0
-    viewStore.producer.startWithValues { count = $0 }
+    viewStore.producer.producer.startWithValues { count = $0 }
 
     XCTAssertEqual(count, 0)
     viewStore.send(())

--- a/Tests/ComposableArchitectureTests/StoreTests.swift
+++ b/Tests/ComposableArchitectureTests/StoreTests.swift
@@ -284,7 +284,7 @@ final class StoreTests: XCTestCase {
       let vs = ViewStore(childStore)
 
       vs
-        .publisher.producer
+        .producer.producer
         .startWithValues { _ in }
 
       vs.send(false)


### PR DESCRIPTION
Change use of `publisher` to `producer` to match ReactiveSwift terminology.
Remove unnecessary storing of `producer` in `ViewStore`.