### PR TITLE
Support for iOS11 (Reopened)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "reactiveswift-composable-architecture",
   platforms: [
-    .iOS(.v12),
+    .iOS(.v11),
     .macOS(.v10_14),
     .tvOS(.v12),
     .watchOS(.v5),

--- a/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
+++ b/Sources/ComposableArchitecture/Debugging/ReducerInstrumentation.swift
@@ -21,7 +21,8 @@ extension Reducer {
   ///   - prefix: A string to print at the beginning of the formatted message for the signpost.
   ///   - log: An `OSLog` to use for signposts.
   /// - Returns: A reducer that has been enhanced with instrumentation.
-  public func signpost(
+    @available(iOS 12.0, *)
+    public func signpost(
     _ prefix: String = "",
     log: OSLog = OSLog(
       subsystem: "co.pointfree.composable-architecture",
@@ -54,6 +55,7 @@ extension Reducer {
 }
 
 extension Effect where Error == Never {
+  @available(iOS 12.0, *)
   func effectSignpost(
     _ prefix: String,
     log: OSLog,

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -199,7 +199,8 @@ final class ReducerTests: XCTestCase {
       ]
     )
   }
-
+    
+  @available(iOS 12.0, *)
   func testDefaultSignpost() {
     let reducer = Reducer<Int, Void, Void>.empty.signpost(log: .default)
     var n = 0
@@ -211,7 +212,8 @@ final class ReducerTests: XCTestCase {
       }
     self.wait(for: [expectation], timeout: 0.1)
   }
-
+    
+  @available(iOS 12.0, *)
   func testDisabledSignpost() {
     let reducer = Reducer<Int, Void, Void>.empty.signpost(log: .disabled)
     var n = 0


### PR DESCRIPTION
Seems like there is no reasonable way for not supporting iOS11 (only `signpost` instrument depends on it, so this PR adds some `@available` attributes).
(_Maybe watchOS & tvOS support can be extended too, but I don't develop for these platforms so I'm not sure about it_ 🙂)
# 
> Unrelated changes removed from the PR