### PR TITLE
Added deprecation for ViewStore `publisher`

### DIFF
--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -49,11 +49,20 @@ public final class ViewStore<State, Action>: ObservableObject {
   @available(
     *, deprecated,
     message:
-      """
-  Consider using `.produced` instead, this variable is added for backward compatibility and will be removed in the next major release.
-  """
+    """
+    Consider using `.produced` instead, this property exists for backwards compatibility and will be removed in the next major release.
+    """
   )
   public var producer: StoreProducer<State> { produced }
+
+  @available(
+    *, deprecated,
+    message:
+    """
+    Consider using `.produced` instead, this property exists for backwards compatibility and will be removed in the next major release.
+    """
+  )
+  public var publisher: StoreProducer<State> { produced }
 
   /// Initializes a view store from a store.
   ///


### PR DESCRIPTION
`ViewStore`'s `publisher` property was renamed to `producer` in #14 but no deprecation was added, making this a breaking changed 🙈  In #19 this was further changed to `produced`, and deprecations were added for *that* change, so this is to also add deprecation for people still using `publisher`, so as to avoid a breaking change.