### PR TITLE
WIP - Add `IdentifiedContainer`, new `DiffableListsOfState` UIKit example

### DIFF
--- a/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
+++ b/Examples/CaseStudies/CaseStudies.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A3E03A32635F30B00660BE9 /* DiffableListsOfState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3E03A22635F30B00660BE9 /* DiffableListsOfState.swift */; };
+		0A3E03A62636075400660BE9 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 0A3E03A52636075400660BE9 /* OrderedCollections */; };
+		0AD0180F2639AECD00E7386E /* CounterCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD0180E2639AECD00E7386E /* CounterCollectionViewCell.swift */; };
+		0AD018112639AF0800E7386E /* IdentifiedStateContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD018102639AF0800E7386E /* IdentifiedStateContainer.swift */; };
 		4F5AC11F24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5AC11E24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift */; };
 		CA0C0C4724B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C0C4624B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift */; };
 		CA0C51FB245389CC00A04EAB /* 04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C51FA245389CC00A04EAB /* 04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift */; };
@@ -147,6 +151,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0A3E03A22635F30B00660BE9 /* DiffableListsOfState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableListsOfState.swift; sourceTree = "<group>"; };
+		0AD0180E2639AECD00E7386E /* CounterCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterCollectionViewCell.swift; sourceTree = "<group>"; };
+		0AD018102639AF0800E7386E /* IdentifiedStateContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiedStateContainer.swift; sourceTree = "<group>"; };
 		4F5AC11E24ECC7E4009DC50B /* 01-GettingStarted-SharedStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "01-GettingStarted-SharedStateTests.swift"; sourceTree = "<group>"; };
 		CA0C0C4624B89BEC00CBDD8A /* 04-HigherOrderReducers-LifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-LifecycleTests.swift"; sourceTree = "<group>"; };
 		CA0C51FA245389CC00A04EAB /* 04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift"; sourceTree = "<group>"; };
@@ -248,6 +255,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A3E03A62636075400660BE9 /* OrderedCollections in Frameworks */,
 				DC1394102469E27300EE1157 /* ComposableArchitecture in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -277,6 +285,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0AD0180D2639AEB400E7386E /* DiffableListsOfState */ = {
+			isa = PBXGroup;
+			children = (
+				0A3E03A22635F30B00660BE9 /* DiffableListsOfState.swift */,
+				0AD0180E2639AECD00E7386E /* CounterCollectionViewCell.swift */,
+				0AD018102639AF0800E7386E /* IdentifiedStateContainer.swift */,
+			);
+			path = DiffableListsOfState;
+			sourceTree = "<group>";
+		};
 		CA6AC25F2451131C00C71CB3 /* 04-HigherOrderReducers-ResuableOfflineDownloads */ = {
 			isa = PBXGroup;
 			children = (
@@ -327,6 +345,7 @@
 				DC630FD92451016B00BAECBA /* ListsOfState.swift */,
 				DC4C6ED92450E6050066A05D /* NavigateAndLoad.swift */,
 				DC25DC602450F2B000082E81 /* LoadThenNavigate.swift */,
+				0AD0180D2639AEB400E7386E /* DiffableListsOfState */,
 				DC25DC622450F2D100082E81 /* Internal */,
 				DC4C6EAF2450DD380066A05D /* Assets.xcassets */,
 				DC4C6EB42450DD380066A05D /* LaunchScreen.storyboard */,
@@ -515,6 +534,7 @@
 			name = UIKitCaseStudies;
 			packageProductDependencies = (
 				DC13940F2469E27300EE1157 /* ComposableArchitecture */,
+				0A3E03A52636075400660BE9 /* OrderedCollections */,
 			);
 			productName = UIKitCaseStudies;
 			productReference = DC4C6EA72450DD380066A05D /* UIKitCaseStudies.app */;
@@ -625,6 +645,9 @@
 				Base,
 			);
 			mainGroup = DC89C40A24460F95006900B9;
+			packageReferences = (
+				0A3E03A42636075400660BE9 /* XCRemoteSwiftPackageReference "swift-collections" */,
+			);
 			productRefGroup = DC89C41424460F95006900B9 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -713,13 +736,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A3E03A32635F30B00660BE9 /* DiffableListsOfState.swift in Sources */,
 				DC4C6ED82450E4570066A05D /* UIViewRepresented.swift in Sources */,
+				0AD018112639AF0800E7386E /* IdentifiedStateContainer.swift in Sources */,
 				DC25DC642450F2DF00082E81 /* ActivityIndicatorViewController.swift in Sources */,
 				DC4C6ED62450E1050066A05D /* CounterViewController.swift in Sources */,
 				DC4C6EDA2450E6050066A05D /* NavigateAndLoad.swift in Sources */,
 				DC4C6EAC2450DD380066A05D /* SceneDelegate.swift in Sources */,
 				DC25DC612450F2B000082E81 /* LoadThenNavigate.swift in Sources */,
 				DC25DC5F2450F13200082E81 /* IfLetStoreController.swift in Sources */,
+				0AD0180F2639AECD00E7386E /* CounterCollectionViewCell.swift in Sources */,
 				DC4C6EAE2450DD380066A05D /* RootViewController.swift in Sources */,
 				DC630FDA2451016B00BAECBA /* ListsOfState.swift in Sources */,
 			);
@@ -1244,7 +1270,23 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		0A3E03A42636075400660BE9 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-collections.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.0.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
+		0A3E03A52636075400660BE9 /* OrderedCollections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0A3E03A42636075400660BE9 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = OrderedCollections;
+		};
 		CAF88E9024B8E3AF00539345 /* ComposableArchitecture */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ComposableArchitecture;

--- a/Examples/CaseStudies/UIKitCaseStudies/DiffableListsOfState/CounterCollectionViewCell.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/DiffableListsOfState/CounterCollectionViewCell.swift
@@ -1,0 +1,80 @@
+import ComposableArchitecture
+import ReactiveSwift
+import UIKit
+
+final class CounterCollectionViewCell: UICollectionViewListCell {
+
+  static var identifier: String { "\(type(of: self))" }
+
+  let countLabel = UILabel()
+
+  var viewStore: ViewStore<CounterState, CounterAction>? {
+    didSet { setUpBindings() }
+  }
+
+  private var disposable: Disposable?
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    setUpSubviews()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  private func setUpSubviews() {
+
+    self.contentView.backgroundColor = .systemBackground
+
+    let decrementButton = UIButton(type: .system)
+    decrementButton.addTarget(self, action: #selector(decrementButtonTapped), for: .touchUpInside)
+    decrementButton.setTitle("−", for: .normal)
+
+    countLabel.font = .monospacedDigitSystemFont(ofSize: 17, weight: .regular)
+
+    let incrementButton = UIButton(type: .system)
+    incrementButton.addTarget(self, action: #selector(incrementButtonTapped), for: .touchUpInside)
+    incrementButton.setTitle("+", for: .normal)
+
+    let rootStackView = UIStackView(arrangedSubviews: [
+      decrementButton,
+      countLabel,
+      incrementButton,
+    ])
+    rootStackView.translatesAutoresizingMaskIntoConstraints = false
+    self.contentView.addSubview(rootStackView)
+
+    NSLayoutConstraint.activate([
+      rootStackView.centerXAnchor.constraint(equalTo: self.contentView.centerXAnchor),
+      rootStackView.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
+    ])
+  }
+
+  private func setUpBindings() {
+
+    guard let viewStore = self.viewStore else { return }
+
+    self.disposable = viewStore.produced.count
+      .map(String.init)
+      .assign(to: \.text, on: countLabel)
+  }
+
+  override func prepareForReuse() {
+
+    super.prepareForReuse()
+
+    self.disposable?.dispose()
+    self.viewStore = nil
+  }
+
+
+  @objc func decrementButtonTapped() {
+    self.viewStore?.send(.decrementButtonTapped)
+  }
+
+  @objc func incrementButtonTapped() {
+    self.viewStore?.send(.incrementButtonTapped)
+  }
+}

--- a/Examples/CaseStudies/UIKitCaseStudies/DiffableListsOfState/DiffableListsOfState.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/DiffableListsOfState/DiffableListsOfState.swift
@@ -1,0 +1,235 @@
+import ComposableArchitecture
+import SwiftUI
+import UIKit
+
+struct DiffableCounterState: Hashable, Identifiable {
+  var id: UUID = .init()
+  var counter: CounterState = .init()
+
+  // custom Equatable/Hashable conformances to only look at the ID for diffing
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.id == rhs.id
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(id)
+  }
+}
+
+let diffableCounterReducer = Reducer<DiffableCounterState, CounterAction, Void> { state, action, _ in
+  switch action {
+  case .decrementButtonTapped:
+    state.counter.count -= 1
+    return .none
+  case .incrementButtonTapped:
+    state.counter.count += 1
+    return .none
+  }
+}
+
+struct DiffableCounterListState: Equatable {
+  var counters: IdentifiedStateContainer<UUID, DiffableCounterState>
+}
+
+enum DiffableCounterListAction: Equatable {
+  case counter(id: UUID, action: CounterAction)
+  case shuffle
+  case insert
+  case remove(id: UUID)
+}
+
+let diffableCounterListReducer: Reducer<DiffableCounterListState, DiffableCounterListAction, Void> = diffableCounterReducer
+  .forEach(
+    state: \DiffableCounterListState.counters,
+    action: /DiffableCounterListAction.counter(id:action:),
+    environment: { _ in () }
+  )
+  .combined(
+    with: Reducer { state, action, _ in
+
+      switch action {
+      case .shuffle:
+        state.counters.shuffle()
+        return .none
+      case .insert:
+        state.counters.append(.init())
+        return .none
+      case .remove(let id):
+        state.counters.remove(id: id)
+        return .none
+      case .counter:
+        return .none
+      }
+
+    }
+  )
+
+final class DiffableCountersTableViewController: UIViewController, UICollectionViewDelegate {
+
+  struct DummySection: Hashable {}
+
+  let store: Store<DiffableCounterListState, DiffableCounterListAction>
+  let viewStore: ViewStore<DiffableCounterListState, DiffableCounterListAction>
+
+  var collectionView: UICollectionView!
+  var dataSource: UICollectionViewDiffableDataSource<DummySection, DiffableCounterState>!
+
+  init(store: Store<DiffableCounterListState, DiffableCounterListAction>) {
+    self.store = store
+    self.viewStore = ViewStore(store)
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    self.title = "Diffable Lists"
+
+    setUpCollectionView()
+    setUpSubviews()
+
+    collectionView.delegate = self
+  }
+
+  private func setUpSubviews() {
+
+    let shuffle = UIButton(type: .roundedRect)
+    shuffle.backgroundColor = .lightGray
+    shuffle.setTitle("Shuffle", for: .normal)
+    shuffle.addTarget(self, action: #selector(shuffleTapped), for: .touchUpInside)
+
+    let insert = UIButton(type: .roundedRect)
+    insert.backgroundColor = .lightGray
+    insert.setTitle("Insert", for: .normal)
+    insert.addTarget(self, action: #selector(insertTapped), for: .touchUpInside)
+
+    let stackView = UIStackView(arrangedSubviews: [shuffle, insert])
+    stackView.distribution = .fillEqually
+
+    view.addSubview(collectionView)
+    view.addSubview(stackView)
+
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+      collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      collectionView.bottomAnchor.constraint(equalTo: stackView.topAnchor),
+      stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+    ])
+  }
+
+  private func setUpCollectionView() {
+
+    var listConfiguration = UICollectionLayoutListConfiguration(appearance: .sidebarPlain)
+    listConfiguration.trailingSwipeActionsConfigurationProvider = { indexPath in
+      UISwipeActionsConfiguration(
+        actions: [
+          .init(
+            style: .destructive,
+            title: "Delete",
+            handler: { [weak self] _, _, completion in
+              guard let id = self?.dataSource.itemIdentifier(for: indexPath)?.id else { return }
+              self?.viewStore.send(.remove(id: id))
+              completion(true)
+            }
+          )
+        ]
+      )
+    }
+
+    self.collectionView = UICollectionView(
+      frame: view.frame,
+      collectionViewLayout: UICollectionViewCompositionalLayout.list(using: listConfiguration)
+    )
+
+    self.collectionView.register(
+      CounterCollectionViewCell.self,
+      forCellWithReuseIdentifier: CounterCollectionViewCell.identifier
+    )
+
+    self.dataSource = .init(collectionView: collectionView, cellProvider: { [store] collectionView, indexPath, state in
+      let cell = collectionView.dequeueReusableCell(
+        withReuseIdentifier: CounterCollectionViewCell.identifier,
+        for: indexPath
+      ) as! CounterCollectionViewCell
+
+      let childStore = store.childStore(
+        for: state.id,
+        state: \.counters,
+        action: DiffableCounterListAction.counter(id:action:)
+      )
+
+      // this extra `scope` could be avoided if we didn't reuse `CounterState` in `DiffableCounterState`
+      cell.viewStore = ViewStore(childStore.scope(state: \.counter))
+
+      return cell
+    })
+
+    self.viewStore.produced.counters
+      .startWithValues { [weak self] in
+
+        var snapshot = NSDiffableDataSourceSnapshot<DummySection, DiffableCounterState>()
+        snapshot.appendSections([.init()])
+        snapshot.appendItems($0.elements)
+
+        // check the window to prevent `UITableViewAlertForLayoutOutsideViewHierarchy` from firing when not visible
+        self?.dataSource.apply(snapshot, animatingDifferences: self?.view.window != nil ? true : false)
+      }
+  }
+
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+
+    guard let id = self.dataSource.itemIdentifier(for: indexPath)?.id else { return }
+
+    self.navigationController?.pushViewController(
+      CounterViewController(
+        store: self.store.childStore(
+          for: id,
+          state: \.counters,
+          action: DiffableCounterListAction.counter(id:action:)
+        )
+        // this extra `scope` could be avoided if we didn't reuse `CounterState` in `DiffableCounterState`
+        .scope(state: \.counter)
+      ),
+      animated: true
+    )
+  }
+
+  @objc func shuffleTapped() {
+    viewStore.send(.shuffle)
+  }
+
+  @objc func insertTapped() {
+    viewStore.send(.insert)
+  }
+}
+
+struct DiffableCountersTableViewController_Previews: PreviewProvider {
+  static var previews: some View {
+    let vc = UINavigationController(
+      rootViewController: DiffableCountersTableViewController(
+        store: Store(
+          initialState: DiffableCounterListState(
+            counters: [
+              DiffableCounterState(),
+              DiffableCounterState(),
+              DiffableCounterState(),
+            ]
+          ),
+          reducer: diffableCounterListReducer,
+          environment: ()
+        )
+      )
+    )
+    return UIViewRepresented(makeUIView: { _ in vc.view })
+  }
+}

--- a/Examples/CaseStudies/UIKitCaseStudies/DiffableListsOfState/IdentifiedStateContainer.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/DiffableListsOfState/IdentifiedStateContainer.swift
@@ -1,0 +1,87 @@
+import ComposableArchitecture
+import OrderedCollections
+
+// Example data structure which is usable with `Reducer.forEach` in iOS < 13 (`IdentifiableArray` is iOS 13+)
+
+struct IdentifiedStateContainer<ID: Hashable, Element>: IdentifiedContainer {
+
+  typealias Index = Int
+
+  typealias ID = ID
+  typealias Element = Element
+
+  private var _storage: OrderedDictionary<ID, Element>
+
+  var elements: [Element] { _storage.elements.map(\.value) }
+
+  init<S: Sequence>(
+    elements: S,
+    id: KeyPath<Element, ID>
+  ) where S.Element == Element {
+    self._storage = .init(uniqueKeysWithValues: elements.map { ($0[keyPath: id], $0) })
+    self.id = id
+  }
+
+  // IdentifiedContainer
+
+  let id: KeyPath<Element, ID>
+
+  subscript(id id: ID) -> Element? {
+    // NB: `_read` crashes Xcode Preview compilation.
+    get { self._storage[id] }
+    _modify { yield &self._storage[id] }
+  }
+
+  // Collection
+
+  var startIndex: Index { _storage.elements.startIndex }
+  var endIndex: Index { _storage.elements.endIndex }
+
+  public func index(after index: Index) -> Index { _storage.elements.index(after: index) }
+
+  subscript(position: Index) -> Element { self._storage.elements[position].value }
+
+  // Partial MutableCollection
+
+  mutating func shuffle() {
+    self._storage.shuffle()
+  }
+
+  // Partial RangeReplaceableCollection
+
+  mutating func append(_ newElement: Element) {
+    let id = newElement[keyPath: self.id]
+    self._storage[id] = newElement
+  }
+
+  mutating func append<S>(contentsOf newElements: S) where S : Sequence, Element == S.Element {
+    self._storage.reserveCapacity(self._storage.count + newElements.underestimatedCount)
+    newElements.forEach { self.append($0) }
+  }
+
+  mutating func remove(at i: Index) -> Element {
+    self._storage.remove(at: i).value
+  }
+
+  // Helpers
+
+  @discardableResult
+  mutating func remove(id: ID) -> Element {
+    let element = self._storage[id]
+    assert(element != nil, "Unexpectedly found nil while removing an identified element.")
+    self._storage[id] = nil
+    return element!
+  }
+}
+
+extension IdentifiedStateContainer: Equatable where Element: Equatable {}
+extension IdentifiedStateContainer: Hashable where Element: Hashable {}
+
+extension IdentifiedStateContainer: ExpressibleByArrayLiteral where Element: Identifiable, Element.ID == ID {
+
+  typealias ArrayLiteralElement = Element
+
+  init(arrayLiteral elements: ArrayLiteralElement...) {
+    self.init(elements: elements, id: \.id)
+  }
+}

--- a/Examples/CaseStudies/UIKitCaseStudies/RootViewController.swift
+++ b/Examples/CaseStudies/UIKitCaseStudies/RootViewController.swift
@@ -41,6 +41,22 @@ let dataSource: [CaseStudy] = [
     )
   ),
   CaseStudy(
+    title: "Diffable Lists",
+    viewController: DiffableCountersTableViewController(
+      store: Store(
+        initialState: DiffableCounterListState(
+          counters: [
+            DiffableCounterState(),
+            DiffableCounterState(),
+            DiffableCounterState(),
+          ]
+        ),
+        reducer: diffableCounterListReducer,
+        environment: ()
+      )
+    )
+  ),
+  CaseStudy(
     title: "Navigate and load",
     viewController: EagerNavigationViewController(
       store: Store(

--- a/Sources/ComposableArchitecture/Reducer.swift
+++ b/Sources/ComposableArchitecture/Reducer.swift
@@ -583,16 +583,15 @@ public struct Reducer<State, Action, Environment> {
   ///     generally considered a logic error, as a child reducer cannot process a child action
   ///     for unavailable child state.
   /// - Returns: A reducer that works on `GlobalState`, `GlobalAction`, `GlobalEnvironment`.
-  @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
-  public func forEach<GlobalState, GlobalAction, GlobalEnvironment, ID>(
-    state toLocalState: WritableKeyPath<GlobalState, IdentifiedArray<ID, State>>,
+    public func forEach<GlobalState, GlobalAction, GlobalEnvironment, ID, LocalContainer>(
+    state toLocalState: WritableKeyPath<GlobalState, LocalContainer>,
     action toLocalAction: CasePath<GlobalAction, (ID, Action)>,
     environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment,
     breakpointOnNil: Bool = true,
     _ file: StaticString = #file,
     _ line: UInt = #line
-
-  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
+  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment>
+    where LocalContainer: IdentifiedContainer, LocalContainer.Element == State, LocalContainer.ID == ID {
     .init { globalState, globalAction, globalEnvironment in
       guard let (id, localAction) = toLocalAction.extract(from: globalAction) else { return .none }
       if globalState[keyPath: toLocalState][id: id] == nil {

--- a/Sources/ComposableArchitecture/SwiftUI/IdentifiedContainer.swift
+++ b/Sources/ComposableArchitecture/SwiftUI/IdentifiedContainer.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public protocol IdentifiedContainer: Collection {
+
+  associatedtype ID: Hashable
+  associatedtype Element
+
+  var id: KeyPath<Element, ID> { get }
+
+  subscript(id id: ID) -> Element? { get set }
+}
+
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+extension IdentifiedArray: IdentifiedContainer {}

--- a/Sources/ComposableArchitecture/UIKit/ForEachUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/ForEachUIKit.swift
@@ -1,0 +1,76 @@
+extension Store where State: Equatable {
+
+  public func forEach<LocalState: Equatable, LocalAction>(
+    state: @escaping (State) -> [LocalState],
+    action: @escaping (Int, LocalAction) -> Action
+  ) -> [Store<LocalState, LocalAction>] {
+    let scopedStore = scope(state: state)
+    let viewStore = ViewStore(scopedStore)
+
+    return zip(viewStore.indices, viewStore.state).map { index, element in
+      scopedStore.scope(
+        state: { index < $0.endIndex ? $0[index] : element },
+        action: { action(index, $0) }
+      )
+    }
+  }
+
+  public func forEach<LocalState: Equatable, LocalAction>(
+    state: @escaping (State) -> [LocalState],
+    action: @escaping (LocalAction) -> Action
+  ) -> [Store<LocalState, LocalAction>] {
+    let scopedStore = scope(state: state)
+    let viewStore = ViewStore(scopedStore)
+
+    return zip(viewStore.indices, viewStore.state).map { index, element in
+      scopedStore.scope(
+        state: { index < $0.endIndex ? $0[index] : element },
+        action: { action($0) }
+      )
+    }
+  }
+}
+
+extension Store where State: Equatable {
+
+  public func forEach<LocalState: Equatable, LocalAction, ID, LocalStateContainer>(
+    state: @escaping (State) -> LocalStateContainer,
+    action: @escaping (ID, LocalAction) -> Action
+  ) -> [Store<LocalState, LocalAction>]
+  where
+    LocalStateContainer: IdentifiedContainer & Equatable,
+    LocalStateContainer.Element == LocalState,
+    LocalStateContainer.ID == ID
+  {
+    let scopedStore = scope(state: state)
+    let viewStore = ViewStore(scopedStore)
+
+    return viewStore.state.map { element in
+      scopedStore.scope(
+        state: { $0[id: element[keyPath: viewStore.id]] ?? element },
+        action: { action(element[keyPath: viewStore.id], $0) }
+      )
+    }
+  }
+
+  public func childStore<LocalState: Equatable, LocalAction, ID, LocalStateContainer>(
+    for id: LocalStateContainer.ID,
+    state: @escaping (State) -> LocalStateContainer,
+    action: @escaping (ID, LocalAction) -> Action
+  ) -> Store<LocalState, LocalAction>
+  where
+    LocalStateContainer: IdentifiedContainer & Equatable,
+    LocalStateContainer.Element == LocalState,
+    LocalStateContainer.ID == ID
+  {
+    let scopedStore = scope(state: state)
+    let viewStore = ViewStore(scopedStore)
+
+    let originalElement = viewStore.state.first { $0[keyPath: viewStore.id] == id }!
+
+    return scopedStore.scope(
+      state: { $0[id: id] ?? originalElement },
+      action: { action(id, $0) }
+    )
+  }
+}


### PR DESCRIPTION
## Motivation

While the main TCA repo is iOS 13.0+, thankfully RAS-TCA has lowered that requirement which allows the less "fortunate" of us to use it in our projects 🙏.

Nonetheless, there are still some "goodies" in RAS-TCA that are iOS 13+, one of them being the `Reducer.forEach` primitive that uses `IdentifiedArray`. As `IdentifiedArray` builds upon `Identifiable` for some of its conformances and extensions which is iOS 13+, it restricts this whole set of functionality to iOS 13+.

By creating a new `IdentifiableContainer` protocol that is not dependent on `Identifiable` and using that on the mentioned
`Reducer.forEach`, we can remove this restriction. Conformance to `IdentifiedArray` is added so everything is backwards compatible, and anyone targeting lower versions than iOS 13 can implement their own container that conforms to that protocol.

Some additional `Store.forEach` helpers were also created to easily create scoped stores for a set of child states.

A new `Store.childStore` helper was created to return a single scoped store for a particular child, from its identifier. This is useful to avoid re-scoping all children when only a subset of children need to be created (e.g. in a diffing set up, where only insertions need to be created).

Finally, a new `DiffableListsOfState` UIKit example was created to demonstrate the usage of these new primitives in a real life scenario. The example showcases a setup with a list of (collection view) cells that have a store and are backed by a diffable data source.

## Changes

- Create new `IdentifiedContainer` protocol, conform `IdentifiedArray` to it.

- Update `Reducer.forEach` primitive that used `IdentifiedArray` to use a `IdentifiedContainer` instead.

- Create new `DiffableListsOfState` UIKit example
  + Create new `IdentifiedStateContainer` example data structure that conforms to `IdentifiedContainer` and wraps a `OrderedDictionary` from `swift-collections`.
  + Create new DiffableCounterList TCA "stack" and `DiffableCountersTableViewController` which uses Diffing in a `UICollectionView` via `UICollectionViewDiffableDataSource`.
  + Create new `CounterCollectionViewCell` which wraps a counter, to demonstrate injecting child stores in cells.

## `DiffableListsOfState` Demo

https://user-images.githubusercontent.com/1391324/116435915-c701ef00-a843-11eb-9a67-b9f3007745fb.mov