### PR TITLE
Update tests to use `TimeInterval` version of `TestScheduler.advance(by:)`

### DIFF
--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/01-GettingStarted-AnimationsTests.swift
@@ -22,37 +22,37 @@ class AnimationTests: XCTestCase {
       $0.circleColor = .red
     }
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     store.receive(.setColor(.blue)) {
       $0.circleColor = .blue
     }
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     store.receive(.setColor(.green)) {
       $0.circleColor = .green
     }
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     store.receive(.setColor(.orange)) {
       $0.circleColor = .orange
     }
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     store.receive(.setColor(.pink)) {
       $0.circleColor = .pink
     }
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     store.receive(.setColor(.purple)) {
       $0.circleColor = .purple
     }
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     store.receive(.setColor(.yellow)) {
       $0.circleColor = .yellow
     }
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     store.receive(.setColor(.white)) {
       $0.circleColor = .white
     }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-TimersTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-TimersTests.swift
@@ -19,11 +19,11 @@ class TimersTests: XCTestCase {
     store.send(.toggleTimerButtonTapped) {
       $0.isTimerActive = true
     }
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     store.receive(.timerTicked) {
       $0.secondsElapsed = 1
     }
-    self.scheduler.advance(by: .seconds(5))
+    self.scheduler.advance(by: 5)
     store.receive(.timerTicked) {
       $0.secondsElapsed = 2
     }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-WebSocketTests.swift
@@ -129,8 +129,8 @@ class WebSocketTests: XCTestCase {
     }
 
     pingSubject.input.send(value: nil)
-    scheduler.advance(by: .seconds(5))
-    scheduler.advance(by: .seconds(5))
+    scheduler.advance(by: 5)
+    scheduler.advance(by: 5)
     store.receive(.pingResponse(nil))
 
     store.send(.connectButtonTapped) {

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-LifecycleTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-LifecycleTests.swift
@@ -23,12 +23,12 @@ class LifecycleTests: XCTestCase {
 
     store.send(.timer(.onAppear))
 
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     store.receive(.timer(.action(.tick))) {
       $0.count = 1
     }
 
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     store.receive(.timer(.action(.tick))) {
       $0.count = 2
     }

--- a/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
+++ b/Examples/CaseStudies/SwiftUICaseStudiesTests/04-HigherOrderReducers-ReusableOfflineDownloadsTests.swift
@@ -45,7 +45,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
     }
 
     self.downloadSubject.input.send(value: .response(Data()))
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     store.receive(.downloadClient(.success(.response(Data())))) {
       $0.mode = .downloaded
     }
@@ -81,10 +81,10 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
     }
 
     self.downloadSubject.input.send(value: .updateProgress(0.6))
-    self.scheduler.advance(by: .milliseconds(500))
+    self.scheduler.advance(by: 0.5)
 
     self.downloadSubject.input.send(value: .updateProgress(0.7))
-    self.scheduler.advance(by: .milliseconds(500))
+    self.scheduler.advance(by: 0.5)
     store.receive(.downloadClient(.success(.updateProgress(0.7)))) {
       $0.mode = .downloading(progress: 0.7)
     }
@@ -166,7 +166,7 @@ class ReusableComponentsDownloadComponentTests: XCTestCase {
     }
 
     self.downloadSubject.input.send(value: .response(Data()))
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     store.receive(.downloadClient(.success(.response(Data())))) {
       $0.alert = nil
       $0.mode = .downloaded

--- a/Examples/Search/SearchTests/SearchTests.swift
+++ b/Examples/Search/SearchTests/SearchTests.swift
@@ -21,7 +21,7 @@ class SearchTests: XCTestCase {
     store.send(.searchQueryChanged("S")) {
       $0.searchQuery = "S"
     }
-    self.scheduler.advance(by: .milliseconds(300))
+    self.scheduler.advance(by: 0.3)
     store.receive(.locationsResponse(.success(mockLocations))) {
       $0.locations = mockLocations
     }
@@ -45,7 +45,7 @@ class SearchTests: XCTestCase {
     store.send(.searchQueryChanged("S")) {
       $0.searchQuery = "S"
     }
-    self.scheduler.advance(by: .milliseconds(300))
+    self.scheduler.advance(by: 0.3)
     store.receive(.locationsResponse(.failure(.init())))
   }
 
@@ -65,7 +65,7 @@ class SearchTests: XCTestCase {
     store.send(.searchQueryChanged("S")) {
       $0.searchQuery = "S"
     }
-    self.scheduler.advance(by: .milliseconds(200))
+    self.scheduler.advance(by: 0.2)
     store.send(.searchQueryChanged("")) {
       $0.searchQuery = ""
     }

--- a/Examples/Todos/TodosTests/TodosTests.swift
+++ b/Examples/Todos/TodosTests/TodosTests.swift
@@ -82,7 +82,7 @@ class TodosTests: XCTestCase {
     store.send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
       $0.todos[id: state.todos[0].id]?.isComplete = true
     }
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     store.receive(.sortCompletedTodos) {
       $0.todos = [
         $0.todos[1],
@@ -118,11 +118,11 @@ class TodosTests: XCTestCase {
     store.send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
       $0.todos[id: state.todos[0].id]?.isComplete = true
     }
-    self.scheduler.advance(by: .milliseconds(500))
+    self.scheduler.advance(by: 0.5)
     store.send(.todo(id: state.todos[0].id, action: .checkBoxToggled)) {
       $0.todos[id: state.todos[0].id]?.isComplete = false
     }
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     store.receive(.sortCompletedTodos)
   }
 
@@ -233,7 +233,7 @@ class TodosTests: XCTestCase {
         $0.todos[2],
       ]
     }
-    self.scheduler.advance(by: .milliseconds(100))
+    self.scheduler.advance(by: 0.1)
     store.receive(.sortCompletedTodos)
   }
 

--- a/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
+++ b/Examples/VoiceMemos/VoiceMemosTests/VoiceMemosTests.swift
@@ -45,15 +45,15 @@ class VoiceMemosTests: XCTestCase {
         url: URL(string: "file:///tmp/DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF.m4a")!
       )
     }
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     store.receive(.currentRecordingTimerUpdated) {
       $0.currentRecording!.duration = 1
     }
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     store.receive(.currentRecordingTimerUpdated) {
       $0.currentRecording!.duration = 2
     }
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
     store.send(.recordButtonTapped) {
       $0.currentRecording!.mode = .encoding
     }
@@ -170,15 +170,15 @@ class VoiceMemosTests: XCTestCase {
     store.send(.voiceMemo(id: url, action: .playButtonTapped)) {
       $0.voiceMemos[id: url]?.mode = VoiceMemo.Mode.playing(progress: 0)
     }
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
     store.receive(VoiceMemosAction.voiceMemo(id: url, action: VoiceMemoAction.timerUpdated(0.5))) {
       $0.voiceMemos[id: url]?.mode = .playing(progress: 0.5)
     }
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
     store.receive(VoiceMemosAction.voiceMemo(id: url, action: VoiceMemoAction.timerUpdated(1))) {
       $0.voiceMemos[id: url]?.mode = .playing(progress: 1)
     }
-    scheduler.advance(by: .milliseconds(100))
+    scheduler.advance(by: 0.1)
     store.receive(
       .voiceMemo(
         id: url,

--- a/Sources/ComposableArchitecture/Effects/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Timer.swift
@@ -57,10 +57,10 @@ extension Effect where Value == Date, Error == Never {
   ///
   ///       store.send(.startButtonTapped)
   ///
-  ///       scheduler.advance(by: .seconds(1))
+  ///       scheduler.advance(by: 1)
   ///       store.receive(.timerTicked) { $0.count = 1 }
   ///
-  ///       scheduler.advance(by: .seconds(5))
+  ///       scheduler.advance(by: 5)
   ///       store.receive(.timerTicked) { $0.count = 2 }
   ///       store.receive(.timerTicked) { $0.count = 3 }
   ///       store.receive(.timerTicked) { $0.count = 4 }

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -55,6 +55,14 @@ import ReactiveSwift
 /// The ``ViewStore`` class is not thread-safe, and all interactions with it must happen on the main
 /// thread. See the documentation of the ``Store`` class for more information why this decision was
 /// made.
+///
+/// ### ViewStore object lifetime
+///
+/// You must always keep a strong reference to any ``ViewStore`` that you create to prevent it from
+/// being immediately deallocated, and thereby preventing its ``produced`` ``StoreProducer`` from
+/// emiting any more state updates. This is primarly an issue when using UIKit, as the SwiftUI
+/// ``WithViewStore`` helper ensures that the ``ViewStore`` is retained.
+///
 @dynamicMemberLookup
 public final class ViewStore<State, Action> {
   #if canImport(Combine)

--- a/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/Tests/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -40,14 +40,14 @@ final class ComposableArchitectureTests: XCTestCase {
     )
 
     store.send(.incrAndSquareLater)
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     store.receive(.squareNow) { $0 = 4 }
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     store.receive(.incrNow) { $0 = 5 }
     store.receive(.squareNow) { $0 = 25 }
 
     store.send(.incrAndSquareLater)
-    scheduler.advance(by: .seconds(2))
+    scheduler.advance(by: 2)
     store.receive(.squareNow) { $0 = 625 }
     store.receive(.incrNow) { $0 = 626 }
     store.receive(.squareNow) { $0 = 391876 }
@@ -63,7 +63,7 @@ final class ComposableArchitectureTests: XCTestCase {
     XCTAssertEqual(values, [])
     testScheduler.advance()
     XCTAssertEqual(values, [1, 42])
-    testScheduler.advance(by: .seconds(2))
+    testScheduler.advance(by: 2)
     XCTAssertEqual(values, [1, 42, 1, 42, 1])
   }
 

--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -88,7 +88,7 @@ final class EffectCancellationTests: XCTestCase {
 
     XCTAssertEqual(value, nil)
 
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     Effect<Never, Never>.cancel(id: CancelToken())
       .start()
 
@@ -240,9 +240,9 @@ final class EffectCancellationTests: XCTestCase {
       .startWithValues { expectedOutput.append($0) }
 
     XCTAssertEqual(expectedOutput, [])
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(expectedOutput, [1])
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(expectedOutput, [1, 2])
   }
 
@@ -259,7 +259,7 @@ final class EffectCancellationTests: XCTestCase {
     disposable.dispose()
 
     XCTAssertEqual(expectedOutput, [])
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(expectedOutput, [])
   }
 }

--- a/Tests/ComposableArchitectureTests/EffectDebounceTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectDebounceTests.swift
@@ -21,25 +21,25 @@ final class EffectDebounceTests: XCTestCase {
     XCTAssertEqual(values, [])
 
     // Waiting half the time also emits nothing
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
     XCTAssertEqual(values, [])
 
     // Run another debounced effect.
     runDebouncedEffect(value: 2)
 
     // Waiting half the time emits nothing because the first debounced effect has been canceled.
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
     XCTAssertEqual(values, [])
 
     // Run another debounced effect.
     runDebouncedEffect(value: 3)
 
     // Waiting half the time emits nothing because the second debounced effect has been canceled.
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
     XCTAssertEqual(values, [])
 
     // Waiting the rest of the time emits the final effect value.
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
     XCTAssertEqual(values, [3])
 
     // Running out the scheduler
@@ -68,12 +68,12 @@ final class EffectDebounceTests: XCTestCase {
     XCTAssertEqual(values, [])
     XCTAssertEqual(effectRuns, 0)
 
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
 
     XCTAssertEqual(values, [])
     XCTAssertEqual(effectRuns, 0)
 
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
 
     XCTAssertEqual(values, [1])
     XCTAssertEqual(effectRuns, 1)

--- a/Tests/ComposableArchitectureTests/EffectDeferredTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectDeferredTests.swift
@@ -19,25 +19,25 @@ final class EffectDeferredTests: XCTestCase {
     XCTAssertEqual(values, [])
 
     // Waiting half the time also emits nothing
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
     XCTAssertEqual(values, [])
 
     // Run another deferred effect.
     runDeferredEffect(value: 2)
 
     // Waiting half the time emits first deferred effect received.
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
     XCTAssertEqual(values, [1])
 
     // Run another deferred effect.
     runDeferredEffect(value: 3)
 
     // Waiting half the time emits second deferred effect received.
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
     XCTAssertEqual(values, [1, 2])
 
     // Waiting the rest of the time emits the final effect value.
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
     XCTAssertEqual(values, [1, 2, 3])
 
     // Running out the scheduler
@@ -64,12 +64,12 @@ final class EffectDeferredTests: XCTestCase {
     XCTAssertEqual(values, [])
     XCTAssertEqual(effectRuns, 0)
 
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
 
     XCTAssertEqual(values, [])
     XCTAssertEqual(effectRuns, 0)
 
-    scheduler.advance(by: .milliseconds(500))
+    scheduler.advance(by: 0.5)
 
     XCTAssertEqual(values, [1])
     XCTAssertEqual(effectRuns, 1)

--- a/Tests/ComposableArchitectureTests/EffectTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectTests.swift
@@ -32,13 +32,13 @@ final class EffectTests: XCTestCase {
 
     XCTAssertEqual(values, [])
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     XCTAssertEqual(values, [1])
 
-    self.scheduler.advance(by: .seconds(2))
+    self.scheduler.advance(by: 2)
     XCTAssertEqual(values, [1, 2])
 
-    self.scheduler.advance(by: .seconds(3))
+    self.scheduler.advance(by: 3)
     XCTAssertEqual(values, [1, 2, 3])
 
     self.scheduler.run()
@@ -56,7 +56,7 @@ final class EffectTests: XCTestCase {
 
     XCTAssertEqual(values, [])
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     XCTAssertEqual(values, [1])
 
     self.scheduler.run()
@@ -75,13 +75,13 @@ final class EffectTests: XCTestCase {
 
     XCTAssertEqual(values, [])
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     XCTAssertEqual(values, [1])
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     XCTAssertEqual(values, [1, 2])
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
     XCTAssertEqual(values, [1, 2, 3])
   }
 
@@ -107,12 +107,12 @@ final class EffectTests: XCTestCase {
     XCTAssertEqual(values, [1, 2])
     XCTAssertEqual(isComplete, false)
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
 
     XCTAssertEqual(values, [1, 2, 3])
     XCTAssertEqual(isComplete, false)
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
 
     XCTAssertEqual(values, [1, 2, 3, 4])
     XCTAssertEqual(isComplete, true)
@@ -141,7 +141,7 @@ final class EffectTests: XCTestCase {
     Effect<Void, Never>.cancel(id: CancelId())
       .startWithValues { _ in }
 
-    self.scheduler.advance(by: .seconds(1))
+    self.scheduler.advance(by: 1)
 
     XCTAssertEqual(values, [1])
     XCTAssertEqual(isComplete, true)

--- a/Tests/ComposableArchitectureTests/ReducerTests.swift
+++ b/Tests/ComposableArchitectureTests/ReducerTests.swift
@@ -49,11 +49,11 @@ final class ReducerTests: XCTestCase {
       $0 = 2
     }
     // Waiting a second causes the fast effect to fire.
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(fastValue, 42)
     // Waiting one more second causes the slow effect to fire. This proves that the effects
     // are merged together, as opposed to concatenated.
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(slowValue, 1729)
   }
 

--- a/Tests/ComposableArchitectureTests/SchedulerTests.swift
+++ b/Tests/ComposableArchitectureTests/SchedulerTests.swift
@@ -13,19 +13,19 @@ final class SchedulerTests: XCTestCase {
 
     XCTAssertEqual(value, nil)
 
-    scheduler.advance(by: .milliseconds(250))
+    scheduler.advance(by: 0.25)
 
     XCTAssertEqual(value, nil)
 
-    scheduler.advance(by: .milliseconds(250))
+    scheduler.advance(by: 0.25)
 
     XCTAssertEqual(value, nil)
 
-    scheduler.advance(by: .milliseconds(250))
+    scheduler.advance(by: 0.25)
 
     XCTAssertEqual(value, nil)
 
-    scheduler.advance(by: .milliseconds(250))
+    scheduler.advance(by: 0.25)
 
     XCTAssertEqual(value, 1)
   }
@@ -106,7 +106,7 @@ final class SchedulerTests: XCTestCase {
     XCTAssertEqual(values, [])
     testScheduler.advance()
     XCTAssertEqual(values, [1, 42])
-    testScheduler.advance(by: .seconds(2))
+    testScheduler.advance(by: 2)
     XCTAssertEqual(values, [1, 42, 42, 1, 42])
   }
 
@@ -126,10 +126,10 @@ final class SchedulerTests: XCTestCase {
     subject.input.send(value: ())
     XCTAssertEqual(count, 0)
 
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(count, 1)
 
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(count, 1)
 
     scheduler.run()

--- a/Tests/ComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/ComposableArchitectureTests/TestStoreTests.swift
@@ -45,7 +45,7 @@ class TestStoreTests: XCTestCase {
 
     store.send(.a)
 
-    testScheduler.advance(by: .seconds(1))
+    testScheduler.advance(by: 1)
 
     store.receive(.b1)
     store.receive(.b2)

--- a/Tests/ComposableArchitectureTests/TimerTests.swift
+++ b/Tests/ComposableArchitectureTests/TimerTests.swift
@@ -11,16 +11,16 @@ final class TimerTests: XCTestCase {
     Effect.timer(id: 1, every: .seconds(1), on: scheduler)
       .startWithValues { _ in count += 1 }
 
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(count, 1)
 
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(count, 2)
 
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(count, 3)
 
-    scheduler.advance(by: .seconds(3))
+    scheduler.advance(by: 3)
     XCTAssertEqual(count, 6)
   }
 
@@ -38,16 +38,16 @@ final class TimerTests: XCTestCase {
     )
     .start()
 
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(count2, 0)
     XCTAssertEqual(count3, 0)
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(count2, 1)
     XCTAssertEqual(count3, 0)
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(count2, 1)
     XCTAssertEqual(count3, 1)
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(count2, 2)
     XCTAssertEqual(count3, 1)
   }
@@ -64,11 +64,11 @@ final class TimerTests: XCTestCase {
       .on(value: { _ in firstCount += 1 })
       .start()
 
-    scheduler.advance(by: .seconds(2))
+    scheduler.advance(by: 2)
 
     XCTAssertEqual(firstCount, 1)
 
-    scheduler.advance(by: .seconds(2))
+    scheduler.advance(by: 2)
 
     XCTAssertEqual(firstCount, 2)
 
@@ -76,12 +76,12 @@ final class TimerTests: XCTestCase {
       .on(value: { _ in secondCount += 1 })
       .startWithValues { _ in }
 
-    scheduler.advance(by: .seconds(2))
+    scheduler.advance(by: 2)
 
     XCTAssertEqual(firstCount, 2)
     XCTAssertEqual(secondCount, 1)
 
-    scheduler.advance(by: .seconds(2))
+    scheduler.advance(by: 2)
 
     XCTAssertEqual(firstCount, 2)
     XCTAssertEqual(secondCount, 2)
@@ -96,13 +96,13 @@ final class TimerTests: XCTestCase {
       .take(first: 3)
       .startWithValues { _ in count += 1 }
 
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(count, 1)
 
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(count, 2)
 
-    scheduler.advance(by: .seconds(1))
+    scheduler.advance(by: 1)
     XCTAssertEqual(count, 3)
 
     scheduler.run()


### PR DESCRIPTION
The latest version of ReactiveSwift has an overload of `TestScheduler.advance(by:)` that accepts a `TimeInterval` in addition to the `DispatchTimeInterval` version, and this is more ergonomic to use, and also more closely matches the upstream code.

Also added a bit of extra documentation about `ViewStore` object lifetimes.