### PR TITLE
Fix git credentials in format.yml

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,9 @@ jobs:
     name: swift-format
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Xcode Select
         run: sudo xcode-select -s /Applications/Xcode_14.1.app
       - name: Tap


### PR DESCRIPTION
## Changes

- Update actions/checkout to v3 in format.yml and disable credentials persistence for the `FORMAT_TOKEN` to be used by
`stefanzweifel/git-auto-commit-action`.