### PR TITLE
Fix ReactiveSwift version pinning in `Package.swift` 🤦

### DIFF
--- a/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ComposableArchitecture.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "ReactiveSwift",
         "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift",
         "state": {
-          "branch": "7.1.0",
+          "branch": null,
           "revision": "509916c99f49a5e6c8196c968b8b7e3dbd48db04",
-          "version": null
+          "version": "7.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
   ],
   dependencies: [
     .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
-    .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", branch: "7.1.0"),
+    .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", from: "7.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.8.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.3.0"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "0.3.2"),


### PR DESCRIPTION
RAS dependency was pointing to a branch named `7.1.0` instead of a *version* named `7.1.0`...